### PR TITLE
fix: Use "exec" for cargo build scripts

### DIFF
--- a/cargo/private/cargo_build_script.bzl
+++ b/cargo/private/cargo_build_script.bzl
@@ -625,7 +625,7 @@ cargo_build_script = rule(
             doc = "The binary script to run, generally a `rust_binary` target.",
             executable = True,
             mandatory = True,
-            cfg = "target",
+            cfg = "exec",
             providers = [CargoBuildScriptRunfilesInfo],
         ),
         "tools": attr.label_list(

--- a/test/cargo_build_script/location_expansion/test.rs
+++ b/test/cargo_build_script/location_expansion/test.rs
@@ -63,22 +63,17 @@ pub fn test_execpath() {
         )
         .1;
 
-    let (data_cfg, data_short_path) = data_path.split_at(
+    let (_data_cfg, data_short_path) = data_path.split_at(
         data_path
             .find("/bin/")
             .unwrap_or_else(|| panic!("Failed to find bin in {}", data_path))
             + "/bin/".len(),
     );
-    let (tool_cfg, tool_short_path) = tool_path.split_at(
+    let (_tool_cfg, tool_short_path) = tool_path.split_at(
         tool_path
             .find("/bin/")
             .unwrap_or_else(|| panic!("Failed to find bin in {}", tool_path))
             + "/bin/".len(),
-    );
-
-    assert_ne!(
-        data_cfg, tool_cfg,
-        "Data and tools should not be from the same configuration."
     );
 
     assert_eq!(


### PR DESCRIPTION
The nuance between when to use exec vs target
is a bit tricky to get right sometimes. You want
to use "exec" for executables that are used at
build time and "target" for runtime dependencies

Since cargo build script are run at build time,
they need to be set to exec.

This fixes circumstances where a user is using
RBE on a platform different than their host machine

For example, I found this bug when I enabled my
linux based RBE cluster when trying to do a
bazel run of a rust binary on my mac. When the
build script executed it threw up because the RBE
cluster was using the mac version of the script.